### PR TITLE
deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,17 +152,33 @@ jobs:
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           docker build -t marketplace-shum:${IMAGE_TAG} .
 
-      - name: Save Docker image to a file
-        run: docker save marketplace-shum:${{ steps.build_image.outputs.IMAGE_TAG }} -o marketplace-shum.tar
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Copy Docker image to EC2
-        uses: appleboy/scp-action@v1.0.0
+      - name: Tag Docker image for GHCR
+        run: |
+          IMAGE_TAG=${{ steps.build_image.outputs.IMAGE_TAG }}
+          docker tag marketplace-shum:${IMAGE_TAG} ghcr.io/${{ github.repository_owner }}/marketplace-shum:${IMAGE_TAG}
+
+      - name: Push Docker image to GHCR
+        run: |
+          IMAGE_TAG=${{ steps.build_image.outputs.IMAGE_TAG }}
+          docker push ghcr.io/${{ github.repository_owner }}/marketplace-shum:${IMAGE_TAG}
+
+      - name: Deploy on EC2 (pull image from registry)
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ vars.HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: "marketplace-shum.tar"
-          target: "/home/ec2-user/app"
+          script: |
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker pull ghcr.io/${{ github.repository_owner }}/marketplace-shum:${{ github.sha }}
+            # Add your deployment steps here, e.g., docker run or docker-compose up
 
       - name: Run migrations on prod
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,89 @@ jobs:
 
       - name: Run tests
         run: clojure -T:build test
+
+  deploy-prod:
+    needs: build
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: prod
+
+    env:
+      ACTIVEMQ_BROKER_URL: tcp://activemq:61616
+      APP_ENV: ${{ vars.APP_ENV }}
+      PORT: ${{ vars.PORT }}
+      HOST: ${{ vars.HOST }}
+      EMAIL_PORT: ${{ vars.EMAIL_PORT }}
+      EMAIL_HOST: ${{ vars.EMAIL_HOST }}
+      EMAIL_USER: ${{ vars.EMAIL_USER }}
+      EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
+      EMAIL_FROM: ${{ vars.EMAIL_FROM }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      DB_HOST: ${{ vars.DB_HOST }}
+      DB_USER: ${{ vars.DB_USER }}
+      DB_PASS: ${{ secrets.DB_PASS }}
+      EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Docker image
+        id: build_image
+        run: |
+          IMAGE_TAG=${{ github.sha }}
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          docker build -t marketplace-shum:${IMAGE_TAG} .
+
+      - name: Save Docker image to a file
+        run: docker save marketplace-shum:${{ steps.build_image.outputs.IMAGE_TAG }} -o marketplace-shum.tar
+
+      - name: Copy Docker image to EC2
+        uses: appleboy/scp-action@v1.0.0
+        with:
+          host: ${{ vars.HOST }}
+          username: ec2-user
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "marketplace-shum.tar"
+          target: "/home/ec2-user/app"
+
+      - name: Run migrations on prod
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ vars.HOST }}
+          username: ec2-user
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            export APP_ENV=prod
+            # Додайте інші змінні, якщо вони потрібні для міграцій
+            # export DB_USER=${{ vars.DB_USER }}
+            cd /home/ec2-user/app
+            clojure -X:migrate
+
+      - name: Deploy on EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ vars.HOST }}
+          username: ec2-user
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /home/ec2-user/app
+            
+            docker load < marketplace-shum.tar
+            
+            IMAGE_TAG=${{ github.sha }}
+            CONTAINER_NAME="marketplace-shum"
+            IMAGE_NAME="marketplace-shum:${IMAGE_TAG}"
+
+            if [ "$(docker ps -q -f name=$CONTAINER_NAME)" ]; then
+                docker stop $CONTAINER_NAME
+                docker rm $CONTAINER_NAME
+            fi
+
+            docker run --env-file=env -d \
+              --name $CONTAINER_NAME \
+              --restart always \
+              -it -p 8032:4000 \
+              $IMAGE_NAME
+            
+            rm marketplace-shum.tar

--- a/README.md
+++ b/README.md
@@ -120,3 +120,14 @@ bin/run -m datomic.peer-server \
   -p 9004 \
   -a shum_access,shum_secret \
   -d shum,"datomic:sql://shum?jdbc:postgresql://postgres-instance.cby2c0iga8z1.eu-central-1.rds.amazonaws.com:5432/marketplace?user=marketplace_user&password=marketplace_password&ssl=true&sslmode=require"
+
+## Datomic run transactor
+
+docker run --env-file=.env -d --name datomic-transactor \
+            --network ci-network \
+            -e JAVA_OPTS="-server -Xms512m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=50" \
+            -e POSTGRES_DB=${{ vars.POSTGRES_DB }} \
+            -e POSTGRES_USER=${{ vars.POSTGRES_USER }} \
+            -e POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }} \
+            -p 8998:8998 -p 8182:8182 \
+            alexandrvirtual/datomic-transactor-test:1.0.7364

--- a/env.example
+++ b/env.example
@@ -1,29 +1,16 @@
-# .env.example
-# Copy this file to .env and fill in your actual values.
-# This file should be added to .gitignore and never committed to version control.
-
-# App Config
-# ---------------------
-# A secret key for signing JWTs
 APP_ENV=dev
-JWT_SECRET=replace_with_a_long_random_secret_string_for_production
-# The public base URL of your service (e.g., https://your-domain.com)
-BASE_URL=http://localhost:3000
 
-# Email Config
-# ---------------------
-EMAIL_HOST=smtp.gmail.com
-EMAIL_PORT=587
-EMAIL_USER=your-email@gmail.com
-# For Gmail, this should be an App Password, not your regular password
-EMAIL_PASS=your_gmail_app_password
-EMAIL_FROM="Shum Marketplace <no-reply@your-domain.com>"
-EMAIL_TLS=true
+EMAIL_HOST="smtp.marketplace.com"
+EMAIL_PORT=
+EMAIL_USER="example@marketplace.com"
+EMAIL_PASS=
+EMAIL_FROM="example@marketplace.com"
 
-# Datomic Pro/Starter License Key Information
-# ---------------------
-# IMPORTANT: You need a Datomic Pro or a FREE Datomic Starter license.
-# You can get one from https://my.datomic.com
-# The key itself MUST be placed inside the `datomic/transactor.properties` file.
-# This variable is just a reminder.
-DATOMIC_LICENSE_KEY_INFO="See datomic/transactor.properties to set your license key" 
+HOST="http://localhost"
+PORT=3000
+
+DB_HOST=localhost
+DB_USER=
+DB_PASS=
+
+JWT_SECRET=ds9v7x@92Hksn28


### PR DESCRIPTION
## Summary by Sourcery

Add a production deployment pipeline in GitHub Actions and update README with Datomic transactor instructions

CI:
- Introduce a deploy-prod job that builds, transfers, migrates, and deploys the Docker image on master push

Deployment:
- Automate copying the built Docker image to EC2, running database migrations, and restarting the production container

Documentation:
- Add instructions for running the Datomic transactor with environment variables in the README