### PR TITLE
add permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: prod
+    permissions:
+      contents: read
+      packages: write
 
     env:
       ACTIVEMQ_BROKER_URL: tcp://activemq:61616


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Grant read access to repository contents and write access to packages for the prod CI job